### PR TITLE
Update to target dotnet 8 and xunit 2.8.1

### DIFF
--- a/src/EAXUnitHelpers.Comparison/CustomEnumerableComparer.cs
+++ b/src/EAXUnitHelpers.Comparison/CustomEnumerableComparer.cs
@@ -12,7 +12,7 @@
         public CustomEnumerableComparer(bool includeAncestorProperties)
         {
             _includeAncestorProperties = includeAncestorProperties;
-            _props = new List<string>();
+            _props = [];
         }
 
         public CustomEnumerableComparer(List<string> props)
@@ -26,7 +26,7 @@
             _props = props;
         }
 
-        public bool Equals(IEnumerable<T> expectedEnumerable, IEnumerable<T> actualEnumerable)
+        public bool Equals(IEnumerable<T>? expectedEnumerable, IEnumerable<T>? actualEnumerable)
         {
             var utilities = new Comparer();
             return utilities.AreEnumerablesEqual(expectedEnumerable, actualEnumerable, _includeAncestorProperties, propertiesToCheck: _props);

--- a/src/EAXUnitHelpers.Comparison/CustomObjectComparer.cs
+++ b/src/EAXUnitHelpers.Comparison/CustomObjectComparer.cs
@@ -12,7 +12,7 @@
         public CustomObjectComparer(bool includeAncestorProperties)
         {
             _includeAncestorProperties = includeAncestorProperties;
-            _props = new List<string>();
+            _props = [];
         }
 
         public CustomObjectComparer(List<string> props)
@@ -26,7 +26,7 @@
             _props = props;
         }
 
-        public bool Equals(T expected, T actual)
+        public bool Equals(T? expected, T? actual)
         {
             var utilities = new Comparer();
             return utilities.AreObjectsEqual(expected, actual, _includeAncestorProperties, _props);

--- a/src/EAXUnitHelpers.Comparison/EAXUnitHelpers.Comparison.csproj
+++ b/src/EAXUnitHelpers.Comparison/EAXUnitHelpers.Comparison.csproj
@@ -5,12 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<IsPackable>true</IsPackable>
-	<VersionPrefix>6.0.0</VersionPrefix>
+	<VersionPrefix>8.0.0</VersionPrefix>
 	<Authors>Engineer Andrew</Authors>
 	<Description>This package provides a custom comparator for objects and enumerables, recursively checking the values of each property on two objects.</Description>
 	<PackageProjectUrl>https://github.com/engineer-andrew/ea-xunit-helpers</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/engineer-andrew/ea-xunit-helpers</RepositoryUrl>
 	<PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
+	<PackageTags>XUnit</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EAXUnitHelpers.Comparison/EAXUnitHelpers.Comparison.csproj
+++ b/src/EAXUnitHelpers.Comparison/EAXUnitHelpers.Comparison.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<IsPackable>true</IsPackable>
@@ -16,7 +16,8 @@
   <ItemGroup>
     <PackageReference Include="EAExtensions.PropertyInfoExtensions" Version="0.0.2" />
     <PackageReference Include="EAExtensions.TypeExtensions" Version="0.0.4" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <ProjectCapability Remove="TestContainer" />
   </ItemGroup>
 
 </Project>

--- a/test/EAXUnitHelpers.Comparison.UnitTests/CustomEnumerableComparerTests.cs
+++ b/test/EAXUnitHelpers.Comparison.UnitTests/CustomEnumerableComparerTests.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EAXUnitHelpers.Comparison.UnitTests
+{
+    public class CustomEnumerableComparerTests
+    {
+        [Fact]
+        public void CustomEnumerableComparerShouldResultInTrueWhenBothEnumerablesAreNull()
+        {
+            // arrange
+            var comparer = new CustomEnumerableComparer<Person>();
+
+            // act
+            var result = comparer.Equals(null, null);
+
+            // assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenTheExpectedEnumerableIsNullAndTheActualEnumerableIsNot()
+        {
+            // arrange
+            var actual = new List<Person>
+            {
+                new()
+                {
+                    Age = 49,
+                    ChangeInPocket = .99m,
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fifi",
+                    LastName = "LeGrange"
+                }
+            };
+            var comparer = new CustomEnumerableComparer<Person>();
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A null collection\r\nActual:   A collection containing 1 objects";
+
+            // act/assert
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(null, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenTheExpectedEnumerableIsNotNullAndTheActualEnumerableIs()
+        {
+            // arrange
+            var expected = new List<Person>
+            {
+                new()
+                {
+                    Age = 49,
+                    ChangeInPocket = .99m,
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fifi",
+                    LastName = "LeGrange"
+                }
+            };
+            var comparer = new CustomEnumerableComparer<Person>();
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A collection containing 1 objects\r\nActual:   A null collection";
+
+            // act/assert
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, null));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenNeitherEnumerableIsNullButTheyHaveADifferentNumberOfObjects()
+        {
+            // arrange
+            var actual = new List<Person>
+            {
+                new()
+                {
+                    Age = 21,
+                    ChangeInPocket = .99m,
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fifi",
+                    LastName = "LeGrange"
+                }
+            };
+            var expected = new List<Person>
+            {
+                new()
+                {
+                    Age = 21,
+                    ChangeInPocket = .99m,
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fifi",
+                    LastName = "LeGrange"
+                },
+                new()
+                {
+                    Age = 21,
+                    ChangeInPocket = .99m,
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fifi",
+                    LastName = "LeGrange"
+                }
+            };
+            var comparer = new CustomEnumerableComparer<Person>();
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: 2 items\r\nActual:   1 items";
+
+            // act/assert
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenNeitherEnumerableIsNullButTheyHaveADifferentNumberOfObjectsInOneOfTheirChildProperties()
+        {
+            // arrange
+            var actual = new List<Person>
+            {
+                new()
+                {
+                    Age = 21,
+                    ChangeInPocket = .99m,
+                    Children =
+                    [
+                        new()
+                        {
+                            Age = 1,
+                            DateOfBirth = DateTime.Today.AddYears(-1),
+                            FirstName = "Baby",
+                            LastName = "LeGrange"
+                        }
+                    ],
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fifi",
+                    LastName = "LeGrange"
+                }
+            };
+            var expected = new List<Person>
+            {
+                new()
+                {
+                    Age = 21,
+                    ChangeInPocket = .99m,
+                    Children = [],
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fifi",
+                    LastName = "LeGrange"
+                }
+            };
+            var comparer = new CustomEnumerableComparer<Person>();
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: 0 items in Children\r\nActual:   1 items in Children";
+
+            // act/assert
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldResultInTrueWhenBothEnumerablesAreEmpty()
+        {
+            // arrange
+            var actual = new List<Person>();
+            var expected = new List<Person>();
+            var comparer = new CustomEnumerableComparer<Person>();
+
+            // act
+            var result = comparer.Equals(expected, actual);
+
+            // assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldThrowAnExceptionWithTheCorrectErrorMessageWhenTheEnumerableTypeIsStringAndOneItemIsDifferent()
+        {
+            // arrange
+            var actual = new List<string> { "Bugs", "Daffy", "Pork", "Elmer" };
+            var expected = new List<string> { "Bugs", "Daffy", "Porky", "Elmer" };
+            var comparer = new CustomEnumerableComparer<string>();
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"Porky\" in position 2\r\nActual:   A value of \"Pork\" in position 2";
+
+            // act/assert
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldThrowAnExceptionWithTheCorrectErrorMessageWhenTheEnumerableTypeIsStringAndTheItemsAreNotInTheSameOrder()
+        {
+            // arrange
+            var actual = new List<string> { "Bugs", "Porky", "Daffy", "Elmer" };
+            var expected = new List<string> { "Bugs", "Daffy", "Porky", "Elmer" };
+            var comparer = new CustomEnumerableComparer<string>();
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"Daffy\" in position 1\r\nActual:   A value of \"Porky\" in position 1";
+
+            // act/assert
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldThrowAnExceptionWithTheCorrectErrorMessageWhenTheEnumerableTypeIsIntAndOneItemIsDifferent()
+        {
+            // arrange
+            var actual = new List<int> { 8, 7, 6, 5, 3, 0, 9 };
+            var expected = new List<int> { 8, 6, 7, 5, 3, 0, 9 };
+            var comparer = new CustomEnumerableComparer<int>();
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"6\" in position 1\r\nActual:   A value of \"7\" in position 1";
+
+            // act/assert
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomEnumerableComparerShouldThrowAnExceptionWithTheCorrectErrorMessageWhenOneOfThePropertiesInOneOfTheEnumerablesIsDifferentFromTheSamePropertyOnTheObjectInTheSamePositionInTheOtherEnumerable()
+        {
+            // arrange
+            var actual = new List<Person>
+            {
+                new()
+                {
+                    Age = 21,
+                    ChangeInPocket = .99m,
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fefe",
+                    LastName = "LeGrange"
+                }
+            };
+            var expected = new List<Person>
+            {
+                new()
+                {
+                    Age = 21,
+                    ChangeInPocket = .99m,
+                    DateOfBirth = DateTime.Today.AddYears(-21),
+                    FirstName = "Fifi",
+                    LastName = "LeGrange"
+                }
+            };
+            var comparer = new CustomEnumerableComparer<Person>();
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"Fifi\" for property \"FirstName\"\r\nActual:   A value of \"Fefe\" for property \"FirstName\"";
+
+            // act/assert
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+    }
+}

--- a/test/EAXUnitHelpers.Comparison.UnitTests/CustomObjectComparerTests.cs
+++ b/test/EAXUnitHelpers.Comparison.UnitTests/CustomObjectComparerTests.cs
@@ -1,12 +1,177 @@
-using EAXUnitHelpers.Comparison.Tests.Models;
 using System;
-using Xunit;
-using Xunit.Sdk;
+using System.Collections.Generic;
 
 namespace EAXUnitHelpers.Comparison.Tests
 {
     public class CustomObjectComparerTests
     {
+        [Fact]
+        public void CustomObjectComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenTheObjectsBeingComparedAreAPrimitiveTypeAndTheValuesAreDifferent()
+        {
+            // arrange
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"Bugs\"\r\nActual:   A value of \"Daffy\"";
+            var comparer = new CustomObjectComparer<string>();
+
+            // act
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals("Bugs", "Daffy"));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomObjectComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenTheObjectsBeingComparedAreADateTimeTypeAndTheValuesAreDifferent()
+        {
+            // arrange
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"6/9/2024 4:49:52 PM\"\r\nActual:   A value of \"6/9/2024 4:49:51 PM\"";
+            var comparer = new CustomObjectComparer<DateTime>();
+            var actual = new DateTime(2024, 06, 09, 16, 49, 51);
+            var expected = new DateTime(2024, 06, 09, 16, 49, 52);
+
+            // act
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomObjectComparerShouldResultInTrueWhenTheObjectsBeingComparedAreDateTimeTypeAndTheValuesAreTheSame()
+        {
+            // arrange
+            var comparer = new CustomObjectComparer<DateTime>();
+            var actual = new DateTime(2024, 06, 09, 16, 49, 51);
+            var expected = new DateTime(2024, 06, 09, 16, 49, 51);
+
+            // act
+            var result = comparer.Equals(expected, actual);
+
+            // assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CustomObjectComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenTheObjectsBeingComparedAreComplexAndDifferOnlyInAParentPropertyWhenParentPropertiesAreSupposedToBeChecked()
+        {
+            // arrange
+            var actual = new Worker
+            {
+                Age = 45,
+                ChangeInPocket = .99m,
+                DateOfBirth = DateTime.Today.AddYears(-45),
+                FirstName = "Fifi",
+                JobTitle = "Software Engineer",
+                LastName = "LeGrange"
+            };
+            var expected = new Worker
+            {
+                Age = 21,
+                ChangeInPocket = .99m,
+                DateOfBirth = DateTime.Today.AddYears(-21),
+                FirstName = "Fifi",
+                JobTitle = "Software Engineer",
+                LastName = "LeGrange"
+            };
+            var comparer = new CustomObjectComparer<Worker>(true);
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"21\" for property \"Age\"\r\nActual:   A value of \"45\" for property \"Age\"";
+
+            // act
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomObjectComparerShouldResultInTrueWhenTheObjectsBeingComparedAreComplexAndDifferOnlyInAParentPropertyWhenParentPropertiesAreNotSupposedToBeChecked()
+        {
+            // arrange
+            var actual = new Worker
+            {
+                Age = 45,
+                ChangeInPocket = .99m,
+                DateOfBirth = DateTime.Today.AddYears(-45),
+                FirstName = "Fifi",
+                JobTitle = "Software Engineer",
+                LastName = "LeGrange"
+            };
+            var expected = new Worker
+            {
+                Age = 21,
+                ChangeInPocket = .99m,
+                DateOfBirth = DateTime.Today.AddYears(-21),
+                FirstName = "Fifi",
+                JobTitle = "Software Engineer",
+                LastName = "LeGrange"
+            };
+            var comparer = new CustomObjectComparer<Worker>();
+
+            // act
+            var result = comparer.Equals(expected, actual);
+
+            // assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CustomObjectComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenTheObjectsBeingComparedAreComplexAndDifferOnlyInAPropertyThatShouldBeCheckedWhenAListOfPropertiesToCheckIsSpecified()
+        {
+            // arrange
+            var actual = new Person
+            {
+                Age = 21,
+                ChangeInPocket = .99m,
+                DateOfBirth = DateTime.Today.AddYears(-21),
+                FirstName = "Fifi",
+                LastName = "LeGrange"
+            };
+            var expected = new Person
+            {
+                Age = 49,
+                ChangeInPocket = .99m,
+                DateOfBirth = DateTime.Today.AddYears(-21),
+                FirstName = "Fifi",
+                LastName = "LeGrange"
+            };
+            var comparer = new CustomObjectComparer<Person>(new List<string> { "Age" });
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"49\" for property \"Age\"\r\nActual:   A value of \"21\" for property \"Age\"";
+
+            // act
+            var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));
+
+            // assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void CustomObjectComparerShouldThrowAnEqualExceptionWithTheCorrectErrorMessageWhenTheObjectsBeingComparedAreComplexAndDifferOnlyInAPropertyThatShouldNotBeCheckedWhenAListOfPropertiesToCheckIsSpecified()
+        {
+            // arrange
+            var actual = new Person
+            {
+                Age = 21,
+                ChangeInPocket = .99m,
+                DateOfBirth = DateTime.Today.AddYears(-21),
+                FirstName = "Fifi",
+                LastName = "LeGrange"
+            };
+            var expected = new Person
+            {
+                Age = 49,
+                ChangeInPocket = .99m,
+                DateOfBirth = DateTime.Today.AddYears(-21),
+                FirstName = "Fifi",
+                LastName = "LeGrange"
+            };
+            var comparer = new CustomObjectComparer<Person>(new List<string> { "ChangeInPocket", "DateOfBirth", "FirstName", "LastName" });
+
+            // act
+            var result = comparer.Equals(expected, actual);
+
+            // assert
+            Assert.True(result);
+        }
+
         [Fact]
         public void CustomObjectComparerShouldResultInTrueWhenTheComparedObjectsAreEqualForPrimitiveTypesAtTheTopLevel()
         {
@@ -83,7 +248,7 @@ namespace EAXUnitHelpers.Comparison.Tests
                 LastName = "LeGrange"
             };
             var comparer = new CustomObjectComparer<Person>();
-            var expectedMessage = "Assert.Equal() Failure\r\nExpected: A value of \"49\" for property \"Age\"\r\nActual:   A value of \"21\" for property \"Age\"";
+            var expectedMessage = "Assert.Equal() Failure: Values differ\r\nExpected: A value of \"49\" for property \"Age\"\r\nActual:   A value of \"21\" for property \"Age\"";
 
             // act
             var exception = Assert.Throws<EqualException>(() => comparer.Equals(expected, actual));

--- a/test/EAXUnitHelpers.Comparison.UnitTests/EAXUnitHelpers.Comparison.UnitTests.csproj
+++ b/test/EAXUnitHelpers.Comparison.UnitTests/EAXUnitHelpers.Comparison.UnitTests.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/EAXUnitHelpers.Comparison.UnitTests/Models/Person.cs
+++ b/test/EAXUnitHelpers.Comparison.UnitTests/Models/Person.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace EAXUnitHelpers.Comparison.Tests.Models
+namespace EAXUnitHelpers.Comparison.UnitTests.Models
 {
     public class Person
     {
@@ -9,14 +9,14 @@ namespace EAXUnitHelpers.Comparison.Tests.Models
 
         public decimal ChangeInPocket { get; set; }
 
-        public IEnumerable<Person> Children { get; set; }
+        public IEnumerable<Person>? Children { get; set; }
 
         public DateTime DateOfBirth { get; set; }
 
-        public string FirstName { get; set; }
+        public string? FirstName { get; set; }
 
-        public string LastName { get; set; }
+        public string? LastName { get; set; }
 
-        public Person Mother { get; set; }
+        public Person? Mother { get; set; }
     }
 }

--- a/test/EAXUnitHelpers.Comparison.UnitTests/Models/Worker.cs
+++ b/test/EAXUnitHelpers.Comparison.UnitTests/Models/Worker.cs
@@ -1,0 +1,7 @@
+﻿namespace EAXUnitHelpers.Comparison.UnitTests.Models
+{
+    internal class Worker : Person
+    {
+        public string? JobTitle { get; set; }
+    }
+}

--- a/test/EAXUnitHelpers.Comparison.UnitTests/usings.cs
+++ b/test/EAXUnitHelpers.Comparison.UnitTests/usings.cs
@@ -1,0 +1,3 @@
+﻿global using EAXUnitHelpers.Comparison.UnitTests.Models;
+global using Xunit;
+global using Xunit.Sdk;


### PR DESCRIPTION
- Target dotnet 8 from 6
- Update xunit dependency version to 2.8.1, which includes adapting to the breaking change introduced in 2.6 where EqualException was changed